### PR TITLE
[FEATURE] Support Binary, Octal and Hex Integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There is currently a lack of documentation but the tests contained should give e
 - [x] Arrays
 - [x] Comments
 - [x] Floats
-- [ ] Hexadecimal, octal, and binary numbers
+- [x] Hexadecimal, octal, and binary numbers
 - [ ] Multi-line strings
 - [ ] String escapes
 - [x] Inline tables


### PR DESCRIPTION
## Changes
- Parses binary, octal, and hexidecimal integers as [described by the TOML 0.5.0 spec](https://toml.io/en/v0.5.0#integer).
- Adds a new test for each type of non-decimal integer.