### PR TITLE
[CI] Rename Reference to Primary Branch, Support Zig v0.10.0

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         runner-os: [ubuntu-latest]
-        zig-version: [ '0.9.1', ]
+        zig-version: [ '0.9.1', '0.10.0' ]
     runs-on: ${{ matrix.runner-os }}
     name: "zig v${{ matrix.zig-version }} on ${{ matrix.runner-os }}"
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,10 +2,10 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This table shows the project's current compatibility status with zig:
 
 | Zig Version | Status |
 | -- | -- |
-| [0.10.0](https://ziglang.org/documentation/0.10.0/) | Supported | 
-| [0.9.1](https://ziglang.org/documentation/0.9.1/) | Supported | 
-| [0.8.1 and below](https://ziglang.org/documentation/0.8.1/) | Not Supported | 
+| [0.10.0](https://ziglang.org/documentation/0.10.0/) | ✅ Supported | 
+| [0.9.1](https://ziglang.org/documentation/0.9.1/) | ✅ Supported | 
+| [0.8.1 and below](https://ziglang.org/documentation/0.8.1/) | ❌ Not Supported |
  
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This table shows the project's current compatibility status with zig:
 
 | Zig Version | Status |
 | -- | -- |
+| [0.10.0](https://ziglang.org/documentation/0.10.0/) | Supported | 
 | [0.9.1](https://ziglang.org/documentation/0.9.1/) | Supported | 
 | [0.8.1 and below](https://ziglang.org/documentation/0.8.1/) | Not Supported | 
  


### PR DESCRIPTION
# Summary of Changes
- Fixes a mistake in the unit test workflow that causes tests not to run during interactions with the `master` branch.
- Adds testing for the latest version, `0.10.0` which introduced [huge changes](https://ziglang.org/download/0.10.0/release-notes.html).
- Update compatibility chart