### PR TITLE
Added JSON stringify function to Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,30 @@ This library is self-contained and requires no dependencies.
 To build simply run `zig build` and that will output a file called `libtoml.a` that you can link with your program.
 
 If you want to run the tests then use the `zig build test` command.
+
+## Installation
+
+Add this to you build.zig
+```zig
+    const zigtoml = b.dependency("zigtoml", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.addModule("toml", zigtoml.module("toml"));
+```
+
+Add this to your build.zig.zon
+
+```zig
+    .zigtoml = .{
+       .url = "https://github.com/aeronavery/zig-toml/archive/refs/heads/master.tar.gz",
+       //hash will be suggested by the zig compiler
+    }
+```
+
+This can then be imported into your code like this
+
+```zig
+const toml = @import("toml");
+
+```

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const Builder = @import("std").build.Builder;
+const std = @import("std");
 
 pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
@@ -10,6 +11,10 @@ pub fn build(b: *Builder) void {
         .target = target,
     });
     b.installArtifact(lib);
+    const module = b.addModule("toml", std.Build.CreateModuleOptions{
+        .source_file = .{ .path = "src/toml.zig" },
+    });
+    lib.addModule("toml", module);
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/toml.zig" },

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,6 @@
-const Builder = @import("std").build.Builder;
 const std = @import("std");
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const lib = b.addStaticLibrary(.{
@@ -11,10 +10,10 @@ pub fn build(b: *Builder) void {
         .target = target,
     });
     b.installArtifact(lib);
-    const module = b.addModule("toml", std.Build.CreateModuleOptions{
-        .source_file = .{ .path = "src/toml.zig" },
+    const module = b.addModule("toml", .{
+        .root_source_file = .{ .path = "src/toml.zig" },
     });
-    lib.addModule("toml", module);
+    lib.root_module.addImport("toml", module);
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/toml.zig" },

--- a/src/toml.zig
+++ b/src/toml.zig
@@ -1650,3 +1650,36 @@ test "stringify_tables" {
         \\{"bazz":{"bar":false,"foo":"hello"},"mizz":{"carp":true}}
     ));
 }
+
+test {
+    const toml =
+        \\[data]
+        \\author = "Robert"
+        \\github = "VisenDev"
+        \\#heres a comment
+        \\
+        \\[numbers]
+        \\list = [1, 2, 3]
+    ;
+    const toml_type = struct {
+        data: struct {
+            author: []const u8,
+            github: []const u8,
+        },
+        numbers: struct {
+            list: []const u32,
+        },
+    };
+
+    var parser = try parseContents(std.testing.allocator, toml);
+    defer parser.deinit();
+
+    var table = try parser.parse();
+    defer table.deinit();
+
+    var json = try table.stringify();
+    defer json.deinit();
+
+    const parsed = try std.json.parseFromSlice(toml_type, std.testing.allocator, json.items, .{});
+    defer parsed.deinit();
+}

--- a/src/toml.zig
+++ b/src/toml.zig
@@ -123,6 +123,7 @@ pub const Value = union(enum) {
                     if (!first_element) {
                         try result.append(',');
                     }
+                    first_element = false;
                     var table_string = try table.stringify();
                     try result.appendSlice(table_string.items);
                     table_string.deinit();


### PR DESCRIPTION
Added capability to JSON stringify TOML Tables, this allows them to be parsed into zig structs very easily with the usage of std.json

This makes it much easier to parse TOML data into a zig struct. This approach was inspired by [my other toml parser](https://github.com/VisenDev/ztoml) which uses a rust backend. I'd rather have a solution in pure zig

Example
```zig

test {
    const toml =
        \\[data]
        \\author = "Robert"
        \\github = "VisenDev"
        \\#heres a comment
        \\
        \\[numbers]
        \\list = [1, 2, 3]
    ;
    const toml_type = struct {
        data: struct {
            author: []const u8,
            github: []const u8,
        },
        numbers: struct {
            list: []const u32,
        },
    };

    var parser = try parseContents(std.testing.allocator, toml);
    defer parser.deinit();

    var table = try parser.parse();
    defer table.deinit();

    var json = try table.stringify();
    defer json.deinit();

    const parsed = try std.json.parseFromSlice(toml_type, std.testing.allocator, json.items, .{});
    defer parsed.deinit();
}
```