### PR TITLE
Bump checkout to v4 to target node20 in CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: "zig v${{ matrix.zig-version }} on ${{ matrix.runner-os }}"
     steps:
       - name: Checkout Correct Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:


### PR DESCRIPTION
`checkout@v3` uses node16 which has been deprecated in github actions. Switching to `checkout@v4` target node20. (Note that this is an insignificant PR but I was using this library today and I saw it was still using v3 so I figured why not bump it)